### PR TITLE
Restrict keyword arguments in RESTART-BIND bindings

### DIFF
--- a/src/restarts.lisp
+++ b/src/restarts.lisp
@@ -153,7 +153,11 @@ apply the restart functions to them."
 
 (defun restart-bind-transform-binding (binding)
   "Transforms the RESTART-BIND binding into a MAKE-RESTART form."
-  (destructuring-bind (name function . arguments) binding
+  (destructuring-bind (name function
+                       &rest arguments
+                       &key report-function test-function interactive-function)
+      binding
+    (declare (ignore report-function test-function interactive-function))
     `(make-restart :name ',name :function ,function ,@arguments)))
 
 (defmacro restart-bind (bindings &body body)


### PR DESCRIPTION
In the current implementation, `:function` or `:name` could be specified as keyword arguments in bindings of a `restart-bind` form which, while harmless, is almost certainly a mistake since their values would be overridden by the supplied function or restart name; `:associated-conditions` can also be specified and I am unsure if this is desirable or not, but this pull request disallows it.