### PR TITLE
 Change DEFINE-CONDITION: signals a TYPE-ERROR if trying to supertype a non-CONDITION

### DIFF
--- a/portable-condition-system.asd
+++ b/portable-condition-system.asd
@@ -9,7 +9,8 @@
   :serial t
   :pathname "src"
   :depends-on (#:alexandria
-               #:split-sequence)
+               #:split-sequence
+               #:closer-mop)
   :components ((:file "package")
                (:file "conditions")
                (:file "condition-hierarchy")
@@ -37,6 +38,7 @@
                (:file "debugger")
                (:file "ansi-test-data")
                (:file "ansi-test-support")
+               (:file "more-tests")
                (:module "ansi-test"
                 :components
                 ((:file "condition")

--- a/src/condition-hierarchy.lisp
+++ b/src/condition-hierarchy.lisp
@@ -8,13 +8,13 @@
 ;;; documentation strings due to the repetitiveness of the contents of this
 ;;; file.
 
-(define-condition warning (condition) ())
+(define-condition-internal warning (condition) ())
 
-(define-condition serious-condition (condition) ())
+(define-condition-internal serious-condition (condition) ())
 
-(define-condition error (serious-condition) ())
+(define-condition-internal error (serious-condition) ())
 
-(define-condition style-warning (warning) ())
+(define-condition-internal style-warning (warning) ())
 
 (defun report-simple-condition (condition stream)
   (let ((format-control (simple-condition-format-control condition))
@@ -24,7 +24,7 @@
         (format stream "Condition ~S was signaled with format arguments ~S."
                 (type-of condition) format-args))))
 
-(define-condition simple-condition ()
+(define-condition-internal simple-condition ()
   ((format-control :reader simple-condition-format-control
                    :initarg :format-control)
    (format-arguments :reader simple-condition-format-arguments
@@ -32,43 +32,43 @@
   (:default-initargs :format-control nil :format-arguments '())
   (:report report-simple-condition))
 
-(define-condition simple-warning (simple-condition warning) ())
+(define-condition-internal simple-warning (simple-condition warning) ())
 
-(define-condition simple-error (simple-condition error) ())
+(define-condition-internal simple-error (simple-condition error) ())
 
-(define-condition storage-condition (serious-condition) ())
+(define-condition-internal storage-condition (serious-condition) ())
 
 (defun report-type-error (condition stream)
   (format stream "~@<The value ~@:_~2@T~S ~@:_is not of type ~@:_~2@T~S.~:@>"
           (type-error-datum condition)
           (type-error-expected-type condition)))
 
-(define-condition type-error (error)
+(define-condition-internal type-error (error)
   ((datum :reader type-error-datum :initarg :datum)
    (expected-type :reader type-error-expected-type :initarg :expected-type))
   (:report report-type-error))
 
-(define-condition simple-type-error (simple-condition type-error) ())
+(define-condition-internal simple-type-error (simple-condition type-error) ())
 
-(define-condition control-error (error) ())
+(define-condition-internal control-error (error) ())
 
-(define-condition program-error (error) ())
+(define-condition-internal program-error (error) ())
 
-(define-condition cell-error (error)
+(define-condition-internal cell-error (error)
   ((name :reader cell-error-name :initarg :name)))
 
 (defun report-unbound-variable (condition stream)
   (format stream "The variable ~S is unbound."
           (cell-error-name condition)))
 
-(define-condition unbound-variable (cell-error) ()
+(define-condition-internal unbound-variable (cell-error) ()
   (:report report-unbound-variable))
 
 (defun report-undefined-function (condition stream)
   (format stream "The function ~S is undefined."
           (cell-error-name condition)))
 
-(define-condition undefined-function (cell-error) ()
+(define-condition-internal undefined-function (cell-error) ()
   (:report report-undefined-function))
 
 (defun report-unbound-slot (condition stream)
@@ -76,45 +76,45 @@
           (cell-error-name condition)
           (unbound-slot-instance condition)))
 
-(define-condition unbound-slot (cell-error)
+(define-condition-internal unbound-slot (cell-error)
   ((instance :reader unbound-slot-instance :initarg :instance))
   (:report report-unbound-slot))
 
-(define-condition stream-error (error)
+(define-condition-internal stream-error (error)
   ((stream :reader stream-error-stream :initarg :stream)))
 
-(define-condition end-of-file (stream-error) ())
+(define-condition-internal end-of-file (stream-error) ())
 
-(define-condition parse-error (error) (stream))
+(define-condition-internal parse-error (error) (stream))
 
-(define-condition reader-error (parse-error stream-error) ())
+(define-condition-internal reader-error (parse-error stream-error) ())
 
-(define-condition package-error (error)
+(define-condition-internal package-error (error)
   ((package :reader package-error-package :initarg :package)))
 
-(define-condition arithmetic-error (error)
+(define-condition-internal arithmetic-error (error)
   ((operation :reader operation-error-operation :initarg :operation)
    (operands :reader operands-error-operands :initarg :operands)))
 
-(define-condition division-by-zero (arithmetic-error) ())
+(define-condition-internal division-by-zero (arithmetic-error) ())
 
-(define-condition floating-point-invalid-operation (arithmetic-error) ())
+(define-condition-internal floating-point-invalid-operation (arithmetic-error) ())
 
-(define-condition floating-point-inexact (arithmetic-error) ())
+(define-condition-internal floating-point-inexact (arithmetic-error) ())
 
-(define-condition floating-point-overflow (arithmetic-error) ())
+(define-condition-internal floating-point-overflow (arithmetic-error) ())
 
-(define-condition floating-point-underflow (arithmetic-error) ())
+(define-condition-internal floating-point-underflow (arithmetic-error) ())
 
-(define-condition file-error (error)
+(define-condition-internal file-error (error)
   ((pathname :reader pathname-error-pathname :initarg :pathname)))
 
-(define-condition print-not-readable (error)
+(define-condition-internal print-not-readable (error)
   ((object :reader print-not-readable-object :initarg :object)))
 
 ;;; Non-standard condition types
 
-(define-condition restart-not-found (control-error)
+(define-condition-internal restart-not-found (control-error)
   ((restart-name :reader restart-not-found-restart-name :initarg :restart-name))
   (:documentation "A condition type signaled when a restart with a given name
 was not found, even thought it was expected.")
@@ -122,7 +122,7 @@ was not found, even thought it was expected.")
              (format stream "Restart ~S is not active."
                      (restart-not-found-restart-name condition)))))
 
-(define-condition abort-failure (control-error) ()
+(define-condition-internal abort-failure (control-error) ()
   (:documentation "A condition type signaled when the ABORT restart invoked by
 function ABORT failed to transfer control outside of the function.")
   (:report "An ABORT restart failed to transfer control."))
@@ -133,7 +133,7 @@ function ABORT failed to transfer control outside of the function.")
           (case-failure-name condition)
           (case-failure-possibilities condition)))
 
-(define-condition case-failure (type-error)
+(define-condition-internal case-failure (type-error)
   ((name :reader case-failure-name :initarg :name)
    (possibilities :reader case-failure-possibilities :initarg :possibilities))
   (:documentation "A condition type signaled when a case assertion

--- a/src/condition-hierarchy.lisp
+++ b/src/condition-hierarchy.lisp
@@ -139,3 +139,17 @@ function ABORT failed to transfer control outside of the function.")
   (:documentation "A condition type signaled when a case assertion
 (such as ECASE, ETYPECASE, CCASE, or CTYPECASE) fails to match its keyform.")
   (:report report-case-failure))
+
+(defun report-invalid-superclass (condition stream)
+  (format stream "~S cannot superclass ~S:~%~S"
+          (invalid-superclass-class condition)
+          (invalid-superclass-superclass condition)
+          (invalid-superclass-reason condition)))
+
+(define-condition invalid-superclass (condition)
+  ((class :reader invalid-superclass-class :initarg :class)
+   (superclass :reader invalid-superclass-superclass :initarg :superclass)
+   (reason :reader invalid-superclass-reason :initarg :reason))
+  (:documentation "A condition type signaled when a class tries to superclass an
+invalid superclass; the violation being described by REASON.")
+  (:report report-invalid-superclass))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -69,6 +69,7 @@
            (:nicknames #:pcs)
            (:import-from #:split-sequence #:split-sequence)
            (:import-from #:alexandria #:parse-body)
+           (:import-from #:closer-mop #:ensure-class-using-class)
            (:shadow ,@symbols)
            (:export ,@symbols))
          (uiop:define-package #:common-lisp+portable-condition-system

--- a/t/ansi-test/define-condition.lisp
+++ b/t/ansi-test/define-condition.lisp
@@ -579,6 +579,41 @@
   (notnot-mv (typep #'condition-27/s1 'generic-function))
   t)
 
+;;; Test non-CONDITION supertypes
+
+(defclass not-a-condition-1 nil nil)
+(defclass not-a-condition-2 nil nil)
+
+(deftest condition-with-non-condition-supertype-1.1
+    (signals-type-error not-a-condition 'not-a-condition-1
+                        (define-condition condition-with-non-condition-supertype-1a (not-a-condition-1)
+                          ()
+                          (:report "condition-with-non-condition-supertype-1a")))
+  t)
+
+(define-condition-with-tests condition-28a nil nil)
+(define-condition-with-tests condition-28b nil nil)
+
+(deftest condition-with-non-condition-supertype-1.2
+    (signals-type-error not-a-condition 'not-a-condition-1
+                        (define-condition condition-with-non-condition-supertype-1b (condition-28a
+                                                                                     not-a-condition-1
+                                                                                     condition-28b)
+                          ()
+                          (:report "condition-with-non-condition-sypertype-1b")))
+  t)
+
+(deftest condition-with-non-condition-supertype-1.3
+    (signals-type-error not-a-condition 'not-a-condition-2
+                        (define-condition condition-with-non-condition-supertype-1c (condition-28b
+                                                                                     not-a-condition-2
+                                                                                     not-a-condition-1)
+                          ()
+                          (:report "condition-with-non-condition-supertype-1c")))
+  t)
+
+;;;
+
 ;;; Documentation
 
 ;;; Pitman says this should have been in the spec, but it isn't really

--- a/t/more-tests.lisp
+++ b/t/more-tests.lisp
@@ -1,0 +1,26 @@
+;;;; t/more-tests.lisp
+
+(in-package #:portable-condition-system/test)
+
+;;; Test superclassing a CONDITION in DEFCLASS
+
+(defclass not-a-condition-0 nil nil)
+
+(define-condition-with-tests condition-in-super-1a nil nil)
+(define-condition-with-tests condition-in-super-1b nil nil)
+
+(deftest condition-in-defclass-superclass-1.1
+    (signals-error (defclass condition-in-defclass-superclass-1a (condition-in-super-1a)
+                     ())
+                   portable-condition-system::invalid-superclass)
+  t)
+
+(deftest condition-in-defclass-superclass-1.2
+    (signals-error (defclass condition-in-defclass-superclass-1b (not-a-condition-0
+                                                                  condition-in-super-1b
+                                                                  condition-in-super-1a)
+                     ())
+                   portable-condition-system::invalid-superclass)
+  t)
+
+;;;


### PR DESCRIPTION
DEFINE-CONDITION seems to have an issue. When called with an object that is not a
CONDITION's subtype, it accepts it anyway:
```common-lisp
CL-USER> (defclass any-class () ())
;; #<STANDARD-CLASS COMMON-LISP-USER::ANY-CLASS>
CL-USER> (macroexpand-1 '(pcs:define-condition foo-condition (any-class other-class)
                          ((foo-slot :reader foo-condition-slot :initarg :slot))
                          (:report "A Report")))

;; (PROGN
;;  (DEFCLASS FOO-CONDITION (ANY-CLASS OTHER-CLASS)
;;            ((FOO-SLOT :READER FOO-CONDITION-SLOT :INITARG :SLOT)))
;;  (DEFMETHOD PRINT-OBJECT ((#:CONDITION759 FOO-CONDITION) #:STREAM760)
;;    (WRITE-STRING "A Report" #:STREAM760))
;;  'FOO-CONDITION)
;; T
CL-USER> (pcs:define-condition foo-condition (any-class other-class)
          ((foo-slot :reader foo-condition-slot :initarg :slot))
          (:report "A Report"))

;; FOO-CONDITION
CL-USER> (subtypep 'foo-condition 'any-class)
;; T
;; T
CL-USER> (subtypep 'foo-condition 'pcs:condition)
;; NIL
;; NIL
```

Adds COERCE-CONDITION-SUPERTYPES and changes EXPAND-DEFINE-CONDITION.
Add DEFINE-CONDITION-INTERNAL to handle internal conditions (DEFINE-CONDITION-INTERNAL
is necessary because we don't know beforehand the relationship between the
internal conditions and CONDITION, needed by COERCE-CONDITION-SUPERTYPES.)

The proposed fix results in:

```common-lisp
CL-USER> (defclass any-class () ())
;; #<STANDARD-CLASS COMMON-LISP-USER::ANY-CLASS>
CL-USER> (macroexpand-1 '(pcs:define-condition foo-condition (any-class other-class)
                          ((foo-slot :reader foo-condition-slot :initarg :slot))
                          (:report "A Report")))
;; (PROGN
;;  (DEFCLASS FOO-CONDITION (PORTABLE-CONDITION-SYSTEM:CONDITION)
;;            ((FOO-SLOT :READER FOO-CONDITION-SLOT :INITARG :SLOT)))
;;  (DEFMETHOD PRINT-OBJECT ((#:CONDITION747 FOO-CONDITION) #:STREAM748)
;;    (WRITE-STRING "A Report" #:STREAM748))
;; 'FOO-CONDITION)
;; T
CL-USER> (pcs:define-condition foo-condition (any-class other-class)
          ((foo-slot :reader foo-condition-slot :initarg :slot))
          (:report "A Report"))
;; FOO-CONDITION
CL-USER> (subtypep 'foo-condition 'any-class)
;; NIL
;; T
CL-USER> (subtypep 'foo-condition 'pcs:condition)
;; T
;; T
```

I'm using SBCL 2.0.11